### PR TITLE
Switch to MySqlConnector

### DIFF
--- a/src/dbup-mysql/MySqlConnectionManager.cs
+++ b/src/dbup-mysql/MySqlConnectionManager.cs
@@ -1,6 +1,6 @@
 ﻿using System.Collections.Generic;
 using DbUp.Engine.Transactions;
-using MySql.Data.MySqlClient;
+using MySqlConnector;
 
 namespace DbUp.MySql
 {

--- a/src/dbup-mysql/MySqlExtensions.cs
+++ b/src/dbup-mysql/MySqlExtensions.cs
@@ -6,7 +6,7 @@ using DbUp.Builder;
 using DbUp.Engine.Output;
 using DbUp.Engine.Transactions;
 using DbUp.MySql;
-using MySql.Data.MySqlClient;
+using MySqlConnector;
 
 /// <summary>
 /// Configuration extension methods for MySql.

--- a/src/dbup-mysql/MySqlExtensions.cs
+++ b/src/dbup-mysql/MySqlExtensions.cs
@@ -231,7 +231,7 @@ public static class MySqlExtensions
         if (string.IsNullOrEmpty(databaseName) || databaseName.Trim() == string.Empty)
             throw new InvalidOperationException("The connection string does not specify a database name.");
 
-        masterConnectionStringBuilder.Database = "mysql";
+        
         masterConnectionString = masterConnectionStringBuilder.ConnectionString;
     }
 }

--- a/src/dbup-mysql/MySqlScriptExecutor.cs
+++ b/src/dbup-mysql/MySqlScriptExecutor.cs
@@ -4,7 +4,7 @@ using DbUp.Engine;
 using DbUp.Engine.Output;
 using DbUp.Engine.Transactions;
 using DbUp.Support;
-using MySql.Data.MySqlClient;
+using MySqlConnector;
 
 namespace DbUp.MySql
 {
@@ -44,7 +44,7 @@ namespace DbUp.MySql
 #if MY_SQL_DATA_6_9_5
                 var code = exception.ErrorCode;
 #else
-                var code = exception.Code;
+                var code = exception.ErrorCode;
 #endif
                 Log().WriteInformation("MySql exception has occurred in script: '{0}'", script.Name);
                 Log().WriteError("Script block number: {0}; MySql error code: {1}; Number {2}; Message: {3}", index, code, exception.Number, exception.Message);

--- a/src/dbup-mysql/dbup-mysql.csproj
+++ b/src/dbup-mysql/dbup-mysql.csproj
@@ -6,7 +6,7 @@
     <Company>DbUp Contributors</Company>
     <Product>DbUp</Product>
     <Copyright>Copyright © DbUp Contributors 2015</Copyright>
-    <TargetFrameworks>netstandard1.3;netstandard2.0;net462</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net462</TargetFrameworks>
     <AssemblyName>dbup-mysql</AssemblyName>
     <RootNamespace>DbUp.MySql</RootNamespace>
     <PackageId>dbup-mysql</PackageId>
@@ -21,25 +21,25 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="dbup-core" Version="5.0.87"/>
+    <PackageReference Include="dbup-core" Version="5.0.87" />
     <PackageReference Include="System.Data.SqlClient" Version="4.8.6" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net462'">
-    <Reference Include="System"/>
-    <PackageReference Include="MySql.Data" Version="6.9.5"/>
+    <PackageReference Include="MySqlConnector">
+      <Version>2.3.7</Version>
+    </PackageReference>
+    <Reference Include="System" />
     <!-- last version to support < .NET 4.5.2. -->
   </ItemGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard1.3'">
-    <PackageReference Include="MySql.Data" Version="6.10.9"/>
-  </ItemGroup>
-
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
-    <PackageReference Include="MySql.Data" Version="8.0.33"/>
+    <PackageReference Include="MySqlConnector">
+      <Version>2.3.7</Version>
+    </PackageReference>
   </ItemGroup>
 
   <ItemGroup>
-    <None Visible="false" Include="../dbup-icon.png" Pack="True" PackagePath=""/>
+    <None Visible="false" Include="../dbup-icon.png" Pack="True" PackagePath="" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
# Checklist
- [x] I have read the [Contributing Guide](https://github.com/DbUp/DbUp/blob/master/CONTRIBUTING.md)
- [ ] I have checked to ensure this does not introduce an unintended breaking changes
- [x] I have considered appropriate testing for my change

# Description

This PR removes the dependency to MySql.Data.MySqlClient and uses the MySqlCOnnector instead. This is required in order to connect to MariaDb V10 > or higher.

In order to get this working support for netstandard1.3 needs to be dropped.

Related to #8
