### PR TITLE
Add custom journal table to UpgradeEngineBuilder

### DIFF
--- a/src/Tests/ApprovalFiles/NoPublicApiChanges.Run.approved.cs
+++ b/src/Tests/ApprovalFiles/NoPublicApiChanges.Run.approved.cs
@@ -5,6 +5,7 @@
 [assembly: System.Runtime.Versioning.TargetFramework(".NETStandard,Version=v2.0", FrameworkDisplayName=".NET Standard 2.0")]
 public static class MySqlExtensions
 {
+    public static DbUp.Builder.UpgradeEngineBuilder JournalToMySqlTable(this DbUp.Builder.UpgradeEngineBuilder builder, string schema, string table) { }
     public static DbUp.Builder.UpgradeEngineBuilder MySqlDatabase(DbUp.Engine.Transactions.IConnectionManager connectionManager) { }
     public static DbUp.Builder.UpgradeEngineBuilder MySqlDatabase(this DbUp.Builder.SupportedDatabases supported, DbUp.Engine.Transactions.IConnectionManager connectionManager) { }
     public static DbUp.Builder.UpgradeEngineBuilder MySqlDatabase(this DbUp.Builder.SupportedDatabases supported, string connectionString) { }

--- a/src/dbup-mysql/MySqlExtensions.cs
+++ b/src/dbup-mysql/MySqlExtensions.cs
@@ -88,6 +88,19 @@ public static class MySqlExtensions
     }
 
     /// <summary>
+    /// Tracks the list of executed scripts in a MySql table.
+    /// </summary>
+    /// <param name="builder">The builder.</param>
+    /// <param name="schema">The schema.</param>
+    /// <param name="table">The table.</param>
+    /// <returns></returns>
+    public static UpgradeEngineBuilder JournalToMySqlTable(this UpgradeEngineBuilder builder, string schema, string table)
+    {
+        builder.Configure(c => c.Journal = new MySqlTableJournal(() => c.ConnectionManager, () => c.Log, schema, table));
+        return builder;
+    }
+
+    /// <summary>
     /// Ensures that the database specified in the connection string exists.
     /// </summary>
     /// <param name="supported">Fluent helper type.</param>


### PR DESCRIPTION
# Checklist
- [X] I have read the [Contributing Guide](https://github.com/DbUp/DbUp/blob/main/CONTRIBUTING.md)
- [X] I have checked to ensure this does not introduce an unintended breaking changes
- [X] I have considered appropriate testing for my change

# Description
Adds a `JournalToMySqlTable` to the `UpgradeEngineBuilder`.  Logic copied from dbup-sqlserver